### PR TITLE
zsh render issue

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,7 @@ func init() {
 			// we are done
 			RequireWindowsCalls = true
 			ClearLinePrefixString = "\r"
+			ClearLineSuffixString = ""
 			return
 		}
 		// since the environment is telling
@@ -59,6 +60,7 @@ func init() {
 	case "solaris", "darwin", "linux", "dragonfly", "freebsd", "netbsd", "openbsd", "plan9":
 		if isBASHLike(shell) {
 			ClearLinePrefixString = "\r"
+			ClearLineSuffixString = ""
 			return
 		}
 		// oh you arent using `bash`, `dash`, or `sh`
@@ -68,6 +70,7 @@ func init() {
 		//
 		// this will likely get more diverse as time goes on
 		ClearLinePrefixString = fmt.Sprintf("%c[%dA%c[K\r", 27, 1, 27)
+		ClearLineSuffixString = "\n"
 		return
 	default:
 		panic(fmt.Sprintf("we not not yet support %s", runtime.GOOS))
@@ -88,6 +91,9 @@ func isBASHLike(shell string) bool {
 
 // ClearLinePrefixString is used to set the clear prefix
 var ClearLinePrefixString string
+
+// ClearLineSuffixString is used to set the clear suffix
+var ClearLineSuffixString string
 
 // RequireWindowsCalls is done to check
 // if while we maybe in windows, we have

--- a/config.go
+++ b/config.go
@@ -67,7 +67,7 @@ func init() {
 		// `csh`, `tcsh`, and `fish`
 		//
 		// this will likely get more diverse as time goes on
-		ClearLinePrefixString = fmt.Sprintf("%c[%dA%c[2K\r", 27, 1, 27)
+		ClearLinePrefixString = fmt.Sprintf("%c[%dA%c[K\r", 27, 1, 27)
 		return
 	default:
 		panic(fmt.Sprintf("we not not yet support %s", runtime.GOOS))

--- a/config.go
+++ b/config.go
@@ -1,0 +1,100 @@
+// Simple console progress bars
+package pb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func init() {
+	// extract the $SHELL environment variable
+	// is the standard mechanism POSIX
+	// for communicating the shell your program
+	// is running within.
+	//
+	// like everything POSIX it doesn't work
+	// 100% of time, as if you launch a
+	// different shell from your normal bash
+	// session SHELL will still contain bash,
+	// not say `zsh` which was launched in a
+	// weird `$ zsh my_program` manner.
+	//
+	// for additional reading:
+	// https://stackoverflow.com/questions/3327013/how-to-determine-the-current-shell-im-working-on
+	shell := os.Getenv("SHELL")
+	switch runtime.GOOS {
+	case "windows":
+		// we need to check if we're
+		// in a windows emulated
+		// shell environment
+		if shell == "" {
+			// this is just a windows shell
+			// we are done
+			RequireWindowsCalls = true
+			ClearLinePrefixString = "\r"
+			return
+		}
+		// since the environment is telling
+		// us this is a POSIX like
+		// environment we will treat it like
+		// such.
+		RequireWindowsCalls = false
+
+		// first we need to check if we
+		// are really being emulated
+		ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond*250)
+		defer cancel()
+		// check if we have access to `stty`
+		//
+		// cygwin will, but git 4 windows and mtty won't
+		// citation:
+		// - personal research
+		UseSTTYWindows = exec.CommandContext(ctx, "stty", "size").Run() == nil
+		fallthrough
+	case "solaris", "darwin", "linux", "dragonfly", "freebsd", "netbsd", "openbsd", "plan9":
+		if isBASHLike(shell) {
+			ClearLinePrefixString = "\r"
+			return
+		}
+		// oh you arent using `bash`, `dash`, or `sh`
+		// we'll set an ugly prefix we know that works
+		// with `zsh` and just pray it works in `ksh`
+		// `csh`, `tcsh`, and `fish`
+		//
+		// this will likely get more diverse as time goes on
+		ClearLinePrefixString = fmt.Sprintf("%c[%dA%c[2K\r", 27, 1, 27)
+		return
+	default:
+		panic(fmt.Sprintf("we not not yet support %s", runtime.GOOS))
+	}
+}
+
+// isBASHLike checks for a bash like shells which are the most common
+func isBASHLike(shell string) bool {
+	shell = strings.TrimSpace(shell)
+	// dash, bash, and sh are mostly identical for our purposes
+	return strings.Contains(shell, "bash") ||
+		strings.Contains(shell, "dash") ||
+		shell == "/bin/sh" ||
+		shell == "/sbin/sh" ||
+		shell == "/usr/bin/sh" ||
+		shell == "/usr/sbin/sh"
+}
+
+// ClearLinePrefixString is used to set the clear prefix
+var ClearLinePrefixString string
+
+// RequireWindowsCalls is done to check
+// if while we maybe in windows, we have
+// access to
+var RequireWindowsCalls bool
+
+// Use STTY can be used on windows in
+// order to ensure sizing works like
+// a normal boring unix terminal
+var UseSTTYWindows bool

--- a/pb.go
+++ b/pb.go
@@ -411,11 +411,11 @@ func (pb *ProgressBar) write(total, current int64) {
 	case isFinish:
 		return
 	case pb.Output != nil:
-		fmt.Fprint(pb.Output, "\r"+out+end)
+		fmt.Fprint(pb.Output, ClearLinePrefixString+out+end)
 	case pb.Callback != nil:
 		pb.Callback(out + end)
 	case !pb.NotPrint:
-		fmt.Print("\r" + out + end)
+		fmt.Print(ClearLinePrefixString + out + end)
 	}
 }
 

--- a/pb.go
+++ b/pb.go
@@ -411,11 +411,11 @@ func (pb *ProgressBar) write(total, current int64) {
 	case isFinish:
 		return
 	case pb.Output != nil:
-		fmt.Fprint(pb.Output, ClearLinePrefixString+out+end)
+		fmt.Fprint(pb.Output, ClearLinePrefixString+out+end+ClearLineSuffixString)
 	case pb.Callback != nil:
 		pb.Callback(out + end)
 	case !pb.NotPrint:
-		fmt.Print(ClearLinePrefixString + out + end)
+		fmt.Print(ClearLinePrefixString + out + end + ClearLineSuffixString)
 	}
 }
 

--- a/pb.go
+++ b/pb.go
@@ -82,6 +82,7 @@ type ProgressBar struct {
 	ForceWidth                       bool
 	ManualUpdate                     bool
 	AutoStat                         bool
+	PadStart                         string
 
 	// Default width for the time box.
 	UnitsWidth   int
@@ -119,6 +120,20 @@ func (pb *ProgressBar) Start() *ProgressBar {
 		pb.ShowPercent = false
 		pb.AutoStat = false
 	}
+
+	// pad new lines
+	// this will break multi-bar functionality
+	// but shiftleft isnt using it
+	if pb.PadStart != "" {
+		if pb.Output != nil {
+			fmt.Fprintf(pb.Output, pb.PadStart)
+		} else if pb.Callback != nil {
+			pb.Callback(pb.PadStart)
+		} else if !pb.NotPrint {
+			fmt.Print(pb.PadStart)
+		}
+	}
+
 	if !pb.ManualUpdate {
 		pb.Update() // Initial printing of the bar before running the bar refresher.
 		go pb.refresher()


### PR DESCRIPTION
### Summery

We switch from the `mpb` to `pb` progress bar library. This fix was coupled with an implicit fix for windows render issues.

The root of the error as far as I can tell is broken `zsh` configurations. Sadly `mpb` uses 3 escape sequences to do what `pb` does with 1. This extra escape sequence allows for it to terminate existing escape sequences which could potentially be opened to be a bad configuration. One should be able to quick see `iTerm2` + `zsh` + `oh-my-zsh` has had rough transition in MacOS Mojave as it appears some of the configuration options in `zsh` were very quietly broken in the transition. 

Either way, backwards compatibility, and cross platform support is king so here we are.

### Motivation

* https://github.com/ShiftLeftSecurity/product/issues/1942

### Changes

* Added a `config.go` who's goal is mostly run `func init()` and set a few varibles
* Added a few modification to the `pb_win.go` to possibly offer support on `mintty`, `cygwin`, `gitbash.exe` https://github.com/cheggaaa/pb/issues/88

### Test

I'll need assistance with this if I could ask for these folks for assistance to see if this works

* @tuxology can I borrow Josh to do windows testing? If we could get screen shots of
  * `powershell.exe`
  * `cmd.exe`
  * `gitbash.exe`
  * `cygwin`
* @Preetam can you test with `zsh` and `bash` in the vanilla `Terminal.app` in MacOS?
* @perrito666 / @prathik23 can either you attempt to duplicate your issue in MacOS?
* @tuxology can you be a control for linux-centric `zsh` ?
